### PR TITLE
Add achievement tracking system

### DIFF
--- a/js/achievements.js
+++ b/js/achievements.js
@@ -1,0 +1,14 @@
+export const achievements = [
+  {
+    id: 'survive_60',
+    title: 'Survivor',
+    description: 'Survive for 60 seconds in one run',
+    condition: (game) => game.runTime >= 60
+  },
+  {
+    id: 'shield_collector',
+    title: 'Shield Collector',
+    description: 'Collect 5 shields in one run',
+    condition: (game) => game.shieldsCollected >= 5
+  }
+];

--- a/js/game.js
+++ b/js/game.js
@@ -4,6 +4,7 @@ import { Player } from "./player.js";
 import { Obstacle } from "./obstacle.js";
 import { Particle } from "./particle.js";
 import { Star } from "./star.js";
+import { achievements } from "./achievements.js";
 
 
 export class Game {
@@ -20,6 +21,11 @@ export class Game {
     this.shieldTimer = 0;
     this.lastFrameTime = performance.now();
     this.keys = { left: false, right: false };
+
+    this.runTime = 0;
+    this.shieldsCollected = 0;
+    this.achievements = achievements;
+    this.achievementState = JSON.parse(localStorage.getItem('achievements')) || {};
 
     this.player = new Player(this);
     this.obstacles = [];
@@ -157,6 +163,8 @@ export class Game {
     this.comboTimer = 0;
     this.shieldActive = false;
     this.shieldTimer = 0;
+    this.runTime = 0;
+    this.shieldsCollected = 0;
     // Return obstacles and particles to their pools.
     this.obstacles.forEach(obs => this.returnObstacle(obs));
     this.particles.forEach(p => this.returnParticle(p));
@@ -200,6 +208,7 @@ export class Game {
   }
   update(dt) {
     if (this.state !== GameStateEnum.PLAYING) return;
+    this.runTime += dt;
     this.player.update(dt, this.keys);
     const obstacleSpeed = this.getObstacleSpeed();
     for (let i = this.obstacles.length - 1; i >= 0; i--) {
@@ -234,6 +243,7 @@ export class Game {
             }
           }
         } else if (obs.type === 'powerup') {
+          this.shieldsCollected++;
           this.shieldActive = true;
           this.shieldTimer = SHIELD_DURATION;
           this.createParticles(obs.x, obs.y, '#00ffff', 15);
@@ -264,7 +274,23 @@ export class Game {
       }
     }
     this.stars.forEach(s => s.update());
+    this.checkAchievements();
   }
+
+  checkAchievements() {
+    this.achievements.forEach(ach => {
+      if (this.achievementState[ach.id]) return;
+      if (ach.condition(this)) {
+        this.unlockAchievement(ach.id);
+      }
+    });
+  }
+
+  unlockAchievement(id) {
+    this.achievementState[id] = true;
+    localStorage.setItem('achievements', JSON.stringify(this.achievementState));
+  }
+
   spawnObstacle() {
     const size = 40;
     const x = Math.random() * (GAME_WIDTH - size) + size / 2;
@@ -322,6 +348,13 @@ export class Game {
     let endMessage = this.score >= this.highScore ? "New High Score!" : "High Score: " + this.highScore;
     this.ctx.fillText(endMessage, GAME_WIDTH / 2, GAME_HEIGHT / 2);
     this.ctx.fillText('Press Space to Restart', GAME_WIDTH / 2, GAME_HEIGHT / 2 + 40);
+    const unlocked = this.achievements.filter(a => this.achievementState[a.id]);
+    if (unlocked.length > 0) {
+      this.ctx.fillText('Achievements:', GAME_WIDTH / 2, GAME_HEIGHT / 2 + 80);
+      unlocked.forEach((a, i) => {
+        this.ctx.fillText(a.title, GAME_WIDTH / 2, GAME_HEIGHT / 2 + 110 + i * 25);
+      });
+    }
   }
   drawPause() {
     this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';


### PR DESCRIPTION
## Summary
- Add `achievements.js` module defining survival and shield collection achievements
- Track achievement conditions in `Game.update` and persist unlocks via `localStorage`
- Show unlocked achievements on the game-over screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a353a28a3c832fb105b187bd33c6fc