### PR TITLE
Add Jest test setup with jsdom environment

### DIFF
--- a/__tests__/placeholder.test.js
+++ b/__tests__/placeholder.test.js
@@ -1,0 +1,3 @@
+test('placeholder works', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "shape-escape",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with ESM support and Jest test script
- configure Jest to use `jsdom` environment
- include placeholder unit test

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a496f30224832fa18b8f78175e7783