### PR TITLE
Add obstacle movement and rotation tests

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -42,7 +42,7 @@ export class Game {
   }
 
   // Object pooling methods
-  getObstacle(x, y, size, type, shape) {
+  getObstacle(x, y, size, type, shape, vx = 0, rotationSpeed = 0) {
     if (this.obstaclePool.length > 0) {
       let obs = this.obstaclePool.pop();
       obs.x = x;
@@ -50,9 +50,12 @@ export class Game {
       obs.size = size;
       obs.type = type;
       obs.shape = shape;
+      obs.vx = vx;
+      obs.rotation = 0;
+      obs.rotationSpeed = rotationSpeed;
       return obs;
     } else {
-      return new Obstacle(x, y, size, type, shape);
+      return new Obstacle(x, y, size, type, shape, vx, rotationSpeed);
     }
   }
   returnObstacle(obs) {

--- a/js/obstacle.js
+++ b/js/obstacle.js
@@ -1,15 +1,20 @@
 import { drawShape } from "./utils.js";
 
 export class Obstacle {
-  constructor(x, y, size, type, shape) {
+  constructor(x, y, size, type, shape, vx = 0, rotationSpeed = 0) {
     this.x = x;
     this.y = y;
     this.size = size;
     this.type = type; // 'normal' or 'powerup'
     this.shape = shape;
+    this.vx = vx;
+    this.rotation = 0;
+    this.rotationSpeed = rotationSpeed;
   }
   update(dt, speed) {
+    this.x += this.vx * dt;
     this.y += speed * dt;
+    this.rotation += this.rotationSpeed * dt;
   }
   draw(ctx) {
     ctx.lineWidth = 3;
@@ -20,17 +25,21 @@ export class Obstacle {
       ctx.strokeStyle = '#fff';
       ctx.save();
       ctx.translate(this.x, this.y);
+      ctx.rotate(this.rotation);
       drawShape(ctx, this.shape, this.size);
       ctx.restore();
     } else if (this.type === 'powerup') {
       ctx.shadowBlur = 0;
       ctx.fillStyle = '#ffd700';
+      ctx.save();
+      ctx.translate(this.x, this.y);
+      ctx.rotate(this.rotation);
       ctx.beginPath();
       let spikes = 5,
           outerRadius = this.size / 2,
           innerRadius = outerRadius / 2;
       let rot = Math.PI / 2 * 3;
-      const cx = this.x, cy = this.y;
+      const cx = 0, cy = 0;
       const step = Math.PI / spikes;
       ctx.moveTo(cx, cy - outerRadius);
       for (let i = 0; i < spikes; i++) {
@@ -45,6 +54,7 @@ export class Obstacle {
       }
       ctx.closePath();
       ctx.fill();
+      ctx.restore();
     }
     ctx.shadowBlur = 0;
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shape-escape",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/obstacle.test.js
+++ b/tests/obstacle.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('Obstacle update moves and rotates based on velocities', async () => {
+  global.window = { devicePixelRatio: 1 };
+  const { Obstacle } = await import('../js/obstacle.js');
+
+  const vx = 3;
+  const rotationSpeed = Math.PI / 4;
+  const obs = new Obstacle(10, 20, 30, 'normal', 'square', vx, rotationSpeed);
+  const dt = 0.5;
+  const speed = 100;
+
+  const initialX = obs.x;
+  const initialY = obs.y;
+  const initialRotation = obs.rotation;
+
+  obs.update(dt, speed);
+
+  assert.equal(obs.x, initialX + vx * dt);
+  assert.ok(Math.abs(obs.rotation - (initialRotation + rotationSpeed * dt)) < 1e-10);
+  assert.equal(obs.y, initialY + speed * dt);
+});


### PR DESCRIPTION
## Summary
- Extend `Obstacle` to handle horizontal velocity and rotation
- Reset velocity and rotation when reusing obstacles from the pool
- Add tests verifying obstacle movement and rotation updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a496f5723c832f9b989f49c5d698d9