### PR TITLE
Add deterministic obstacle spawn tests

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -42,7 +42,7 @@ export class Game {
   }
 
   // Object pooling methods
-  getObstacle(x, y, size, type, shape) {
+  getObstacle(x, y, size, type, shape, vx = 0, rotationSpeed = 0) {
     if (this.obstaclePool.length > 0) {
       let obs = this.obstaclePool.pop();
       obs.x = x;
@@ -50,9 +50,12 @@ export class Game {
       obs.size = size;
       obs.type = type;
       obs.shape = shape;
+      obs.vx = vx;
+      obs.rotationSpeed = rotationSpeed;
+      obs.rotation = 0;
       return obs;
     } else {
-      return new Obstacle(x, y, size, type, shape);
+      return new Obstacle(x, y, size, type, shape, vx, rotationSpeed);
     }
   }
   returnObstacle(obs) {
@@ -269,12 +272,14 @@ export class Game {
     const size = 40;
     const x = Math.random() * (GAME_WIDTH - size) + size / 2;
     const y = -size / 2;
+    const vx = Math.random() * 200 - 100; // Horizontal velocity between -100 and 100
+    const rotationSpeed = Math.random() * 5 - 2.5; // Rotation speed between -2.5 and 2.5
     if (Math.random() < 0.1) {
-      this.obstacles.push(this.getObstacle(x, y, 30, 'powerup', 'star'));
+      this.obstacles.push(this.getObstacle(x, y, 30, 'powerup', 'star', vx, rotationSpeed));
     } else {
       const shapes = ['circle', 'square', 'triangle'];
       const shape = shapes[Math.floor(Math.random() * shapes.length)];
-      this.obstacles.push(this.getObstacle(x, y, size, 'normal', shape));
+      this.obstacles.push(this.getObstacle(x, y, size, 'normal', shape, vx, rotationSpeed));
     }
   }
   draw() {

--- a/js/obstacle.js
+++ b/js/obstacle.js
@@ -1,15 +1,21 @@
 import { drawShape } from "./utils.js";
 
 export class Obstacle {
-  constructor(x, y, size, type, shape) {
+  constructor(x, y, size, type, shape, vx = 0, rotationSpeed = 0) {
     this.x = x;
     this.y = y;
     this.size = size;
     this.type = type; // 'normal' or 'powerup'
     this.shape = shape;
+    // Horizontal velocity and rotation speed are optional and default to 0.
+    this.vx = vx;
+    this.rotationSpeed = rotationSpeed;
+    this.rotation = 0;
   }
   update(dt, speed) {
     this.y += speed * dt;
+    this.x += this.vx * dt;
+    this.rotation += this.rotationSpeed * dt;
   }
   draw(ctx) {
     ctx.lineWidth = 3;
@@ -20,31 +26,35 @@ export class Obstacle {
       ctx.strokeStyle = '#fff';
       ctx.save();
       ctx.translate(this.x, this.y);
+      ctx.rotate(this.rotation);
       drawShape(ctx, this.shape, this.size);
       ctx.restore();
     } else if (this.type === 'powerup') {
       ctx.shadowBlur = 0;
       ctx.fillStyle = '#ffd700';
+      ctx.save();
+      ctx.translate(this.x, this.y);
+      ctx.rotate(this.rotation);
       ctx.beginPath();
       let spikes = 5,
           outerRadius = this.size / 2,
           innerRadius = outerRadius / 2;
       let rot = Math.PI / 2 * 3;
-      const cx = this.x, cy = this.y;
       const step = Math.PI / spikes;
-      ctx.moveTo(cx, cy - outerRadius);
+      ctx.moveTo(0, -outerRadius);
       for (let i = 0; i < spikes; i++) {
-        let x = cx + Math.cos(rot) * outerRadius;
-        let y = cy + Math.sin(rot) * outerRadius;
+        let x = Math.cos(rot) * outerRadius;
+        let y = Math.sin(rot) * outerRadius;
         ctx.lineTo(x, y);
         rot += step;
-        x = cx + Math.cos(rot) * innerRadius;
-        y = cy + Math.sin(rot) * innerRadius;
+        x = Math.cos(rot) * innerRadius;
+        y = Math.sin(rot) * innerRadius;
         ctx.lineTo(x, y);
         rot += step;
       }
       ctx.closePath();
       ctx.fill();
+      ctx.restore();
     }
     ctx.shadowBlur = 0;
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "shape-escape",
+  "version": "1.0.0",
+  "description": "Shape Escape is a fast-paced, minimalist arcade game built with HTML and JavaScript. Control your shape, morph to match falling obstacles, dash to reach distant targets, and now—try to beat your high score within a session!",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Provide minimal browser-like globals required by the game modules.
+global.window = { devicePixelRatio: 1 };
+global.document = { addEventListener() {}, removeEventListener() {} };
+global.localStorage = { getItem() { return '0'; }, setItem() {} };
+global.performance = { now: () => 0 };
+global.requestAnimationFrame = () => {};
+
+// Dynamically import Game after globals are set.
+const { Game } = await import('../js/game.js');
+
+function createGame() {
+  const canvas = {};
+  const ctx = {};
+  return new Game(canvas, ctx);
+}
+
+test('spawnObstacle sets velocity and rotation from Math.random for normal obstacle', async () => {
+  const game = createGame();
+  const originalRandom = Math.random;
+  const seq = [0.5, 0.2, 0.3, 0.5, 0.75];
+  let i = 0;
+  Math.random = () => seq[i++];
+  try {
+    game.spawnObstacle();
+  } finally {
+    Math.random = originalRandom;
+  }
+  const obs = game.obstacles[0];
+  assert.equal(obs.type, 'normal');
+  assert.equal(obs.shape, 'triangle');
+  assert.equal(obs.vx, 0.2 * 200 - 100);
+  assert.equal(obs.rotationSpeed, 0.3 * 5 - 2.5);
+  assert.equal(i, 5);
+});
+
+test('spawnObstacle spawns powerup when probability threshold met', async () => {
+  const game = createGame();
+  const originalRandom = Math.random;
+  const seq = [0.4, 0.6, 0.7, 0.05];
+  let i = 0;
+  Math.random = () => seq[i++];
+  try {
+    game.spawnObstacle();
+  } finally {
+    Math.random = originalRandom;
+  }
+  const obs = game.obstacles[0];
+  assert.equal(obs.type, 'powerup');
+  assert.equal(obs.shape, 'star');
+  assert.equal(obs.vx, 0.6 * 200 - 100);
+  assert.equal(obs.rotationSpeed, 0.7 * 5 - 2.5);
+  assert.equal(i, 4);
+});


### PR DESCRIPTION
## Summary
- add horizontal velocity and rotation support to obstacles
- randomize velocity, rotation and power-up spawn in `spawnObstacle`
- cover obstacle spawning with deterministic Node tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a496f66d3c832fa3549367e423a494