### PR TITLE
Add collision tests for rotated shapes

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -82,18 +82,34 @@ export function drawShield(ctx, shape, size, offset) {
 // Collision and geometry helpers.
 export function getVertices(entity) {
   let vertices = [];
-  const { x, y, size, shape } = entity;
+  const { x, y, size, shape, rotation = 0 } = entity;
+  const half = size / 2;
   if (shape === 'square') {
-    const half = size / 2;
-    vertices.push({ x: x - half, y: y - half });
-    vertices.push({ x: x + half, y: y - half });
-    vertices.push({ x: x + half, y: y + half });
-    vertices.push({ x: x - half, y: y + half });
+    vertices = [
+      { x: -half, y: -half },
+      { x: half, y: -half },
+      { x: half, y: half },
+      { x: -half, y: half },
+    ];
   } else if (shape === 'triangle') {
-    const half = size / 2;
-    vertices.push({ x: x, y: y - half });
-    vertices.push({ x: x - half, y: y + half });
-    vertices.push({ x: x + half, y: y + half });
+    vertices = [
+      { x: 0, y: -half },
+      { x: -half, y: half },
+      { x: half, y: half },
+    ];
+  } else {
+    return vertices;
+  }
+
+  if (rotation !== 0) {
+    const cos = Math.cos(rotation);
+    const sin = Math.sin(rotation);
+    vertices = vertices.map((v) => ({
+      x: x + v.x * cos - v.y * sin,
+      y: y + v.x * sin + v.y * cos,
+    }));
+  } else {
+    vertices = vertices.map((v) => ({ x: x + v.x, y: y + v.y }));
   }
   return vertices;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shape-escape",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/collision.test.js
+++ b/tests/collision.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Stub window for modules that expect it (config.js)
+global.window = { devicePixelRatio: 1 };
+const { refinedCollisionDetection } = await import('../js/utils.js');
+
+const degToRad = (deg) => (deg * Math.PI) / 180;
+
+test('rotated square collides with axis-aligned square', () => {
+  const base = { x: 0, y: 0, size: 20, shape: 'square', rotation: 0 };
+  const rotated = { x: 21, y: 0, size: 20, shape: 'square', rotation: degToRad(45) };
+  assert.ok(refinedCollisionDetection(base, rotated));
+});
+
+test('rotated square positioned away does not collide', () => {
+  const base = { x: 0, y: 0, size: 20, shape: 'square', rotation: 0 };
+  const rotated = { x: 40, y: 0, size: 20, shape: 'square', rotation: degToRad(45) };
+  assert.ok(!refinedCollisionDetection(base, rotated));
+});
+
+test('rotated square collides with circle when overlapping', () => {
+  const square = { x: 0, y: 0, size: 20, shape: 'square', rotation: degToRad(45) };
+  const circle = { x: 5, y: 0, size: 20, shape: 'circle' };
+  assert.ok(refinedCollisionDetection(square, circle));
+});


### PR DESCRIPTION
## Summary
- support rotation in `getVertices` so refined collision detection handles rotated polygons
- add tests for collisions between rotated squares and circles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a496f846fc832fbf6f206e20c77d36