### PR TITLE
Improve visibility and performance

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -35,6 +35,11 @@ export class Game {
     this.obstaclePool = [];
     this.particlePool = [];
 
+    // Cache background gradient to avoid re-creating it every frame.
+    this.backgroundGradient = ctx.createLinearGradient(0, 0, 0, GAME_HEIGHT);
+    this.backgroundGradient.addColorStop(0, '#111');
+    this.backgroundGradient.addColorStop(1, '#222');
+
     // Create starfield
     const starCount = 50;
     for (let i = 0; i < starCount; i++) {
@@ -318,10 +323,7 @@ export class Game {
       return;
     }
     // Draw background starfield.
-    const grad = this.ctx.createLinearGradient(0, 0, 0, GAME_HEIGHT);
-    grad.addColorStop(0, '#111');
-    grad.addColorStop(1, '#222');
-    this.ctx.fillStyle = grad;
+    this.ctx.fillStyle = this.backgroundGradient;
     this.ctx.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
     this.stars.forEach(s => s.draw(this.ctx));
     this.obstaclePreviews.forEach(p => p.draw(this.ctx));
@@ -333,10 +335,7 @@ export class Game {
     if (this.state === GameStateEnum.PAUSED) this.drawPause();
   }
   drawStartMenu() {
-    const grad = this.ctx.createLinearGradient(0, 0, 0, GAME_HEIGHT);
-    grad.addColorStop(0, '#111');
-    grad.addColorStop(1, '#222');
-    this.ctx.fillStyle = grad;
+    this.ctx.fillStyle = this.backgroundGradient;
     this.ctx.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
     this.ctx.fillStyle = '#fff';
     this.ctx.textAlign = 'center';

--- a/js/obstacle.js
+++ b/js/obstacle.js
@@ -58,7 +58,7 @@ export class ObstaclePreview {
     this.type = type;
     this.shape = shape;
     this.timer = 0;
-    this.duration = 0.5;
+    this.duration = 1.0;
     this.alpha = 0;
   }
   update(dt) {
@@ -68,8 +68,8 @@ export class ObstaclePreview {
   }
   draw(ctx) {
     ctx.save();
-    ctx.globalAlpha = 0.3 + 0.7 * this.alpha;
-    ctx.lineWidth = 3;
+    ctx.globalAlpha = 0.5 + 0.5 * this.alpha;
+    ctx.lineWidth = 5;
     ctx.shadowBlur = 0;
     const flash = Math.floor(Date.now() / 200) % 2 === 0;
     if (this.type === 'powerup') {
@@ -80,7 +80,7 @@ export class ObstaclePreview {
       ctx.strokeStyle = flash ? '#ff0000' : '#ffffff';
     }
     ctx.translate(this.x, this.y);
-    drawShape(ctx, this.shape, this.size);
+    drawShape(ctx, this.shape, this.size * 1.1);
     ctx.restore();
   }
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,7 +1,19 @@
 import { GAME_WIDTH, GAME_HEIGHT } from "./config.js";
 
+// Scale factors to keep different shapes visually consistent.
+const SHAPE_SCALES = {
+  circle: 1.1,
+  square: 1.0,
+  triangle: 1.25,
+};
+
+function getScaledSize(size, shape) {
+  return size * (SHAPE_SCALES[shape] || 1);
+}
+
 // Draws a shape based on type.
 export function drawShape(ctx, shape, size) {
+  size = getScaledSize(size, shape);
   const half = size / 2;
   ctx.beginPath();
   if (shape === 'circle') {
@@ -35,6 +47,7 @@ export function drawShape(ctx, shape, size) {
 }
 
 export function drawShield(ctx, shape, size, offset) {
+  size = getScaledSize(size, shape);
   const half = size / 2;
   ctx.lineWidth = 4;
   ctx.strokeStyle = '#00ffff';
@@ -83,14 +96,15 @@ export function drawShield(ctx, shape, size, offset) {
 export function getVertices(entity) {
   let vertices = [];
   const { x, y, size, shape } = entity;
+  const scaled = getScaledSize(size, shape);
   if (shape === 'square') {
-    const half = size / 2;
+    const half = scaled / 2;
     vertices.push({ x: x - half, y: y - half });
     vertices.push({ x: x + half, y: y - half });
     vertices.push({ x: x + half, y: y + half });
     vertices.push({ x: x - half, y: y + half });
   } else if (shape === 'triangle') {
-    const half = size / 2;
+    const half = scaled / 2;
     vertices.push({ x: x, y: y - half });
     vertices.push({ x: x - half, y: y + half });
     vertices.push({ x: x + half, y: y + half });
@@ -168,24 +182,27 @@ export function refinedCollisionDetection(a, b) {
   const aIsCircle = (a.shape === 'circle') || !validPolygonShapes.includes(a.shape);
   const bIsCircle = (b.shape === 'circle') || !validPolygonShapes.includes(b.shape);
 
+  const sizeA = getScaledSize(a.size, a.shape);
+  const sizeB = getScaledSize(b.size, b.shape);
+
   if (aIsCircle && bIsCircle) {
     const dx = a.x - b.x;
     const dy = a.y - b.y;
-    const rA = a.size / 2;
-    const rB = b.size / 2;
+    const rA = sizeA / 2;
+    const rB = sizeB / 2;
     return (dx * dx + dy * dy) <= ((rA + rB + buffer) ** 2);
   }
   if (aIsCircle && !bIsCircle) {
-    const circle = { x: a.x, y: a.y, r: a.size / 2 + buffer };
-    const poly = getVertices(b);
+    const circle = { x: a.x, y: a.y, r: sizeA / 2 + buffer };
+    const poly = getVertices({ ...b, size: sizeB });
     return circlePolygonCollision(circle, poly);
   }
   if (bIsCircle && !aIsCircle) {
-    const circle = { x: b.x, y: b.y, r: b.size / 2 + buffer };
-    const poly = getVertices(a);
+    const circle = { x: b.x, y: b.y, r: sizeB / 2 + buffer };
+    const poly = getVertices({ ...a, size: sizeA });
     return circlePolygonCollision(circle, poly);
   }
-  const polyA = getVertices(a);
-  const polyB = getVertices(b);
+  const polyA = getVertices({ ...a, size: sizeA });
+  const polyB = getVertices({ ...b, size: sizeB });
   return polygonCollision(polyA, polyB);
 }


### PR DESCRIPTION
## Summary
- scale shapes uniformly for consistent sizing and collisions
- lengthen and brighten obstacle previews for clearer telegraphing
- cache background gradient to reduce per-frame work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49d207b18832fabf7396d86676de3